### PR TITLE
Parse logs with orangebox

### DIFF
--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -291,7 +291,7 @@ class Trace:
         weights = abs(spec.real)
         avr_thr = np.abs(thr).max(axis=1)
 
-        hist2d=self.hist2d(avr_thr, freq,weights,[101,len(freq)/4])
+        hist2d=self.hist2d(avr_thr, freq,weights,[101,len(freq)//4])
 
         filt_width = 3  # width of gaussian smoothing for hist data
         hist2d_sm = gaussian_filter1d(hist2d['hist2d_norm'], filt_width, axis=1, mode='constant')

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -935,8 +935,8 @@ class BB_log:
                     else:
                         output = open(bbl_session[:-3]+'01.csv', "w")
                         parser = orangebox.Parser.load(bbl_session)
-                        with output as f1:
-                            writer = csv.writer(f1)
+                        with output as f:
+                            writer = csv.writer(f)
                             writer.writerow(parser.field_names)
                             for frame in parser.frames():
                                 writer.writerow(frame.data)

--- a/PID-Analyzer.py
+++ b/PID-Analyzer.py
@@ -14,6 +14,8 @@ from scipy.ndimage.filters import gaussian_filter1d
 import matplotlib.colors as colors
 from scipy.optimize import minimize, basinhopping
 from six.moves import input as sinput
+import orangebox
+import csv
 
 
 # ----------------------------------------------------------------------------------
@@ -681,7 +683,7 @@ class CSV_log:
         datdic = {}
         global correctdebugmode
         ### keycheck for 'usecols' only reads usefull traces, uncommend if needed
-        wanted =  ['time (us)',
+        wanted =  ['time (us)','time',
                    'rcCommand[0]', 'rcCommand[1]', 'rcCommand[2]', 'rcCommand[3]',
                    'axisP[0]','axisP[1]','axisP[2]',
                    'axisI[0]', 'axisI[1]', 'axisI[2]',
@@ -695,7 +697,7 @@ class CSV_log:
                    #'energyCumulative (mAh)','vbatLatest (V)', 'amperageLatest (A)'
                    ]
         data = read_csv(fpath, header=0, skipinitialspace=1, usecols=lambda k: k in wanted, dtype=np.float64)
-        datdic.update({'time_us': data['time (us)'].values * 1e-6})
+        datdic.update({'time_us': data['time (us)'].values * 1e-6 if 'time (us)' in data.columns else data['time'].values * 1e-6})
         datdic.update({'throttle': data['rcCommand[3]'].values})
 
         correctdebugmode = not np.any(data['debug[3]']) # if debug[3] contains data, debug_mode is not correct for plotting
@@ -928,7 +930,16 @@ class BB_log:
             size_bytes = os.path.getsize(os.path.join(self.tmp_dir, bbl_session))
             if size_bytes > LOG_MIN_BYTES:
                 try:
-                    msg = subprocess.check_call([self.blackbox_decode_bin_path, bbl_session])
+                    if os.path.isfile(self.blackbox_decode_bin_path):
+                        msg = subprocess.check_call([self.blackbox_decode_bin_path, bbl_session])
+                    else:
+                        output = open(bbl_session[:-3]+'01.csv', "w")
+                        parser = orangebox.Parser.load(bbl_session)
+                        with output as f1:
+                            writer = csv.writer(f1)
+                            writer.writerow(parser.field_names)
+                            for frame in parser.frames():
+                                writer.writerow(frame.data)
                     loglist.append(bbl_session)
                 except:
                     logging.error(
@@ -981,12 +992,14 @@ if __name__ == "__main__":
     except:
         args.noise_bounds = args.noise_bounds
     if not os.path.isfile(blackbox_decode_path):
-        parser.error(
+        logging.warning(
             ('Could not find Blackbox_decode.exe (used to generate CSVs from '
-             'your BBL file) at %s. You may need to install it from '
+             'your BBL file) at %s. You may want to install it from '
              'https://github.com/cleanflight/blackbox-tools/releases.')
             % blackbox_decode_path)
-    logging.info('Decoding with %r' % blackbox_decode_path)
+        logging.info('Decoding with orangebox')
+    else:
+        logging.info('Decoding with %r' % blackbox_decode_path)
 
     logging.info(Version)
     logging.info('Hello Pilot!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy==1.4.1
 pandas==0.25.3
 matplotlib==3.1.2
 six==1.13.0
+orangebox         # version right now is "0.1.1b0", the hope is they do a proper release some time soon


### PR DESCRIPTION
Fixes annoying necessity of having blackbox_decode binary [in all bblog dirs?]

Also, seems like blackbox_decode can not handle newer logs properly anymore.  
I keep seeing warnings like this in logs (BF 4.1.2):
`2 frames failed to decode, rendering 76 loop iterations unreadable. 84812 iterations are missing in total (21277ms, 50.04%)`

The generated diagrams do not differ much though. From one side it proofs the approach with `orangebox` works, from another side seem like that 50% dropped iterations do not contribute much anyway :)

See also:
- https://pypi.org/project/orangebox/
- https://github.com/atomgomba/orangebox/